### PR TITLE
Fix the load balancing command look in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ rules; one for scaling up and another for scaling down.
 
 1. Start the load test:
 
-    loadtest -c 20 --rps 200 -k https://<your-url-here>/?n=1000
+        loadtest -c 20 --rps 200 -k https://<your-url-here>/?n=1000
 
     The `--rps` flag here indicates the requests per second. To stress load your app, you need to send 200 requests per second, asking your app to find how many prime numbers there are between 1 and 1000. For more information about the loadtest tool, see the [loadtest GitHub repo](https://github.com/alexfernandez/loadtest).
 
@@ -221,7 +221,7 @@ rules; one for scaling up and another for scaling down.
 
 1. Run another load test but with 75% less requests per second:
 
-    loadtest -c 20 --rps 50 -k https://<your-url-here>/?n=1000
+        loadtest -c 20 --rps 50 -k https://<your-url-here>/?n=1000
 
     Go back to the metrics, and you will find that the CPU usage is decreasing. It will stabilize at around 3% ~ 4%.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Before I get started I’d like to point out that the Cloud Foundry lite plan on
 
 1. Target a Cloud Foundry org and space:  
 
-     `ibmcloud target --cf`.
+     `ibmcloud target --cf`
 
 1. If you want, you can change the application name by editing the **name** value in the `manifest.yml` file to your application name. For example, _my-app-name_.
 


### PR DESCRIPTION
The load balancing commands were not written as code blocks (no indentation) which made them appear like loadtest -c 20 --rps 200 -k https:///?n=1000. I just added the indentation.